### PR TITLE
新規登録画面で確認のビューを追加

### DIFF
--- a/app/assets/stylesheets/_procedure.scss
+++ b/app/assets/stylesheets/_procedure.scss
@@ -1,0 +1,104 @@
+.procedure-wrap{
+  background: black;
+  color: white;
+  width: 100%;
+  height: 100vh;
+  .procedure-title{
+    font-size: 25px;
+    padding: 50px 50px 70px;
+    font-family: 'Impact', sans-serif;
+    &__border{
+      border-bottom: solid 2px #AAAAAA;
+    }
+  }
+  .procedure-box{
+    margin: auto;
+    text-align: center;
+    height: 65%;
+    width: 80%;
+    color: black;
+    background: whitesmoke;
+    &__header{
+      font-size: 23px;
+      font-weight: bold;
+      padding: 50px 0 50px;
+    }
+    .confirmation-contents{
+      display: flex;
+      justify-content: center;
+      &__icon{
+        margin-right: 35px;
+      }
+      .procedure-icon{
+        border-radius: 50%;
+      }
+      .procedure-icon::before{
+        font-size: 120px;
+      }
+      &__box{
+        width: 50%;
+        margin-left: 35px;
+      }
+    }
+    &__text{
+      margin-top: 100px;
+    }
+  }
+  .procedure-footer{
+    text-align: center;
+    &__forward{
+      height: 60px;
+      width: 170px;
+      padding: 5px;
+      font-size: 20px;
+      background: #008BBB;
+      margin: 40px 0 40px 0;
+    }
+    &__back{
+      height: 60px;
+      width: 170px;
+      padding: 5px;
+      font-size: 20px;
+      background: #008BBB;
+      margin: 40px 40px 0 0;
+    }
+    &__end{
+      height: 60px;
+      width: 170px;
+      padding: 5px;
+      font-size: 20px;
+      background: #008BBB;
+      margin: 40px 0 0;
+    }
+    .procedure-link{
+      color: black;
+      text-decoration: none;
+    }
+  }
+}
+
+
+
+
+
+.compleate-box{
+  margin: auto;
+  text-align: center;
+  height: 400px;
+  width: 900px;
+  color: black;
+  background: whitesmoke;
+  &__user-name{
+    font-size: 23px;
+    font-weight: bold;
+    padding: 50px 0 8px;
+  }
+  &__title{
+    font-size: 23px;
+    font-weight: bold;
+  }
+  &__text{
+    margin-top: 7%;
+    line-height: 3em;
+  }
+}

--- a/app/views/users/compleate.html.haml
+++ b/app/views/users/compleate.html.haml
@@ -1,0 +1,17 @@
+.procedure-wrap
+  %h1.procedure-title
+    registration is compleated !
+    .procedure-title__border
+  .compleate-box
+    .compleate-box__user-name
+      = @user.name
+      様
+    .compleate-box__title
+      会員登録ありがとうございます
+    .compleate-box__text
+      「Login Page」ボタンからログインしてアプリケーションをご利用ください
+      %br
+      EventGeek supports your event !
+  .procedure-footer
+    %button.procedure-footer__end
+      = link_to "Login Page", root_path, class: "procedure-link"

--- a/app/views/users/confirmation.html.haml
+++ b/app/views/users/confirmation.html.haml
@@ -1,0 +1,51 @@
+.procedure-wrap
+  %h1.procedure-title
+    registration confirmation
+    .procedure-title__border
+  .procedure-box
+    .procedure-box__header
+      登録内容の確認
+    .confirmation-contents
+      - if @user.avatar.attached?   #has_one_attachedで画像機能を作成した場合、attached?で画像の有無を確認する。存在すればtrueを返す
+        .confirmation-contents__icon
+          = image_tag @user.avatar, height: "120px", width: "120px", class: "procedure-icon"
+        %table.confirmation-contents__box
+          %thead
+            %tr
+              %th Name
+              %td.confirmation-contents__box--user-name
+                = @user.name
+            %tr
+              %th Email
+              %td.confirmation-contents__box--email
+                = @user.email
+            %tr
+              %th Password
+              %td.confirmation-contents__box--password
+                セキュリティーのためパスワードは非表示となっています
+      - else
+        .confirmation-contents__icon
+          = icon "fas", "user", class: "procedure-icon"
+        %table.confirmation-contents__box
+          %thead
+            %tr
+              %th Name
+              %td.confirmation-contents__box--user-name
+                = @user.name
+            %tr
+              %th Email
+              %td.confirmation-contents__box--email
+                = @user.email
+            %tr
+              %th Password
+              %td.confirmation-contents__box--password
+                セキュリティーのためパスワードは非表示となっています
+    .procedure-box__text
+      内容を確認し、よろしければ「登録」ボタンを押して下さい。
+      %br/
+      ※登録した内容はMY PAGEで編集できます。
+  .procedure-footer
+    %button.procedure-footer__back
+      = link_to "戻る", user_path(@user.id), method: :delete, class: "procedure-link"
+    %button.procedure-footer__forward
+      = link_to "登録", compleate_user_path(@user.id), class: "procedure-link"


### PR DESCRIPTION
#WHAT
新規登録時の確認と完了画面を追加


#WHY
新規登録時、ユーザーが自ら入力した情報を確認させ、登録が完了したことを知らせるため