### PR TITLE
マイページの編集画面を追加

### DIFF
--- a/app/views/users/new_email.html.haml
+++ b/app/views/users/new_email.html.haml
@@ -1,0 +1,11 @@
+.form-wrap
+  %h1.form-title--green
+    Account Update
+  = form_with model: @user, url: {controller: "users", action:"update"} do |f|
+    .form-field
+      = f.label :email, "New Email"
+      %br/
+      = f.email_field :email, autofocus: true, autocomplete: "email", class: "input-field", placeholder: 'PC・携帯どちらでも可', required: true
+    .actions
+      = f.submit "Update!", class: "form-submit__green"
+  = render "share/navigation"

--- a/app/views/users/new_icon.html.haml
+++ b/app/views/users/new_icon.html.haml
@@ -1,0 +1,15 @@
+.form-wrap
+  %h1.form-title--green
+    Account Update
+  = form_with model: @user, url: {controller: "users", action:"update"} do |f|
+    .form-icon__title
+      Icon
+    .form-description
+      ※設定は任意です
+      .form-field
+        = f.label :avatar, "ファイルを選択", class: "icon-select"
+        #myfile= f.file_field :avatar, class: "input-file"
+        %img#avatar{style: "width:127px;height:127px;"}
+    .actions
+      = f.submit "Update!", class: "form-submit__green"
+  = render "share/navigation"

--- a/app/views/users/new_password.html.haml
+++ b/app/views/users/new_password.html.haml
@@ -1,0 +1,15 @@
+.form-wrap
+  %h1.form-title--green
+    Account Update
+  = form_with model: @user, url: {controller: "users", action:"update"} do |f|
+    .form-field
+      = f.label :password, "New Password"
+      %br/
+      = f.password_field :password, autocomplete: "new-password", class: "input-field", placeholder: '6文字以上', required: true
+    .form-field
+      = f.label :password_confirmation, "New Password_confirmation"
+      %br/
+      = f.password_field :password_confirmation, autocomplete: "new-password", class: "input-field", placeholder: '6文字以上', required: true
+    .actions
+      = f.submit "Update!", class: "form-submit__green"
+  = render "share/navigation"


### PR DESCRIPTION
#WHAT
ユーザー情報編集画面を追加

#WHY
情報編集画面を個別に設定することで編集したい情報だけを更新することができるので、ユーザーにとって情報編集を扱い易くするため。