### PR TITLE
含まれるユーザーによって表示が変わるタスクに変更

### DIFF
--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -6,7 +6,7 @@
   height: calc(100vh - 68px - 98px);
   width: 100%;
   padding: 5% 0 5% 0;
-  overflow: auto;
+  overflow-x: auto;
   .task-form{
     display: none;
     text-align: center;
@@ -80,7 +80,7 @@
         height: 2.8em;
         background-color:  black;
         font-size: 16px;
-        color: #008BBB;
+        color: white;
         font-weight: bold;
         margin-top: 1em;
         border-color: #008BBB;
@@ -92,9 +92,11 @@
     display: flex;
     .task-box{
       width: 21em;
-      margin: 0 3.5em 0;
+      margin: 0 5% 0;
       &__title{
         background: #FFCC00;
+        color: black;
+        border: solid 1px #999999;
         height: 3em;
         font-weight: bold;
         font-size: 1.5em;
@@ -121,7 +123,7 @@
           padding: 0.5em;
           list-style-type: none!important;
           font-weight: bold;
-          height: 3.5em;
+          height: 3.9375em;
           box-sizing: border-box;
           overflow: hidden;
           .task-list__icons{
@@ -179,9 +181,8 @@
   .deadline-box{
     display: flex;
     justify-content: center;
-    // border: solid 1px black;
     display: inline-block;
-    margin-bottom: 3.5em;
+    margin-bottom: 3.8em;
     font-size: 1.3em;
     background: black;
     border-radius: 7px;
@@ -209,10 +210,13 @@
     height: 30em;
     width: 60%;
     background: whitesmoke;
-    box-sizing: border-box;
-    border: solid 1px black;
-    margin-bottom: 10em;
+    border-top: solid 0.0625em #999999;
+    border-right: solid 0.0625em #999999;
+    margin-bottom: 8em;
+    border-left: solid 0.8125em steelblue;
+    border-bottom: solid 0.4375em #dadada;
     &__title{
+      box-sizing: border-box;
       background: #c4c4c4;
       font-size: 1.5em;
       padding: 0.7em;
@@ -257,7 +261,7 @@
       white-space: nowrap;    //はみ出しを折り返さない
       overflow-x: auto;       //横方向のスクロール
       width: 60%;
-      height: 80px;
+      height: 100px;
       margin: auto;
       margin-bottom: 6em;
       margin-top: 2em;
@@ -266,15 +270,15 @@
         margin-right: 1.5em;
         margin-left: 1.5em;
         .task-avatar{
-          height: 3.1em;
-          width: 3.1em;
+          height: 3.75em;
+          width: 3.75em;
           border-radius: 50%;
           display: inline-block;
         }
         .task-avatar__blank{
-          font-size: 2.5em;
+          font-size: 3.75em;
           display: inline-block;
-          padding-bottom: 0.2em;
+          margin-bottom: 0.11em;
         }
       }
     }
@@ -355,6 +359,7 @@
     height: 2.8em;
     padding: 5px;
     box-sizing: border-box;
+    background: white;
   }
 }
 
@@ -369,4 +374,16 @@
   text-decoration: none;
   font-size: 15px;
   color: #BA002F;
+}
+
+
+.icon__check{
+  color: #BA002F;
+}
+
+
+.details-member__list--name{
+  max-width: 3.75em;
+  overflow-x: hidden;
+  font-size: 1.1em;
 }

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -39,64 +39,106 @@
         = f.hidden_field :category_id, value: 1, class: "hidden-field"
       -#   = f.collection_select(:category_id, @category, :id, :name, {prompt: "----"}, class: "select-field")
       .task-form__js--submit
-        = f.submit "create", class: "form-submit__js--green"
+        = f.submit "send", class: "form-submit__js--green"
 
   .task-field
     .task-box
       .task-box__title
         Product back log
         #back-log.task__add
-          = icon "fa", "plus-square", class: "plus-square"
+          = icon "far", "plus-square", class: "plus-square"
       %ul#add--back-log.task-box__content
         - @group.tasks.each do |task|
-          - if task.category_id == 1
-            %li.task-box__content--list
-              .task-list__title
-                = task.title
-              .task-list__icons
-                = link_to group_task_path(@group, task), class: "list-link" do
-                  = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
-                = link_to edit_group_task_path(@group, task), class: "list-link" do
-                  = icon "fas", "edit"
-                = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
-                  = icon "fas", "trash-alt"
+          -if current_user && task.user_ids.include?(current_user.id)
+            - if task.category_id == 1
+              %li.task-box__content--list
+                .task-list__title
+                  = icon "fa", "check", class:"icon__check"
+                  = task.title
+                .task-list__icons
+                  = link_to group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
+                  = link_to edit_group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "edit"
+                  = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
+                    = icon "fas", "trash-alt"
+          - else
+            - if task.category_id == 1
+              %li.task-box__content--list
+                .task-list__title
+                  = task.title
+                .task-list__icons
+                  = link_to group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
+                  = link_to edit_group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "edit"
+                  = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
+                    = icon "fas", "trash-alt"
 
     .task-box
       .task-box__title
         Doing
         #doing.task__add
-          = icon "fa", "plus-square", class: "plus-square"
+          = icon "far", "plus-square", class: "plus-square"
       %ul#add--doing.task-box__content
         - @group.tasks.each do |task|
-          - if task.category_id == 2
-            %li.task-box__content--list
-              .task-list__title
-                = task.title
-              .task-list__icons
-                = link_to group_task_path(@group, task), class: "list-link" do
-                  = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
-                = link_to edit_group_task_path(@group, task), class: "list-link" do
-                  = icon "fas", "edit"
-                = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
-                  = icon "fas", "trash-alt"
+          -if current_user && task.user_ids.include?(current_user.id)
+            - if task.category_id == 2
+              %li.task-box__content--list
+                .task-list__title
+                  = icon "fa", "check", class:"icon__check"
+                  = task.title
+                .task-list__icons
+                  = link_to group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
+                  = link_to edit_group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "edit"
+                  = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
+                    = icon "fas", "trash-alt"
+          - else
+            - if task.category_id == 2
+              %li.task-box__content--list
+                .task-list__title
+                  = task.title
+                .task-list__icons
+                  = link_to group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
+                  = link_to edit_group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "edit"
+                  = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
+                    = icon "fas", "trash-alt"
 
     .task-box
       .task-box__title
         Compleate
         #compleate.task__add
-          = icon "fa", "plus-square", class: "plus-square"
+          = icon "far", "plus-square", class: "plus-square"
       %ul#add--compleate.task-box__content
         - @group.tasks.each do |task|
-          - if task.category_id == 3
-            %li.task-box__content--list
-              .task-list__title
-                = task.title
-              .task-list__icons
-                = link_to group_task_path(@group, task), class: "list-link" do
-                  = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
-                = link_to edit_group_task_path(@group, task), class: "list-link" do
-                  = icon "fas", "edit"
-                = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
-                  = icon "fas", "trash-alt"
+          -if current_user && task.user_ids.include?(current_user.id)
+            - if task.category_id == 3
+              %li.task-box__content--list
+                .task-list__title
+                  = icon "fa", "check", class:"icon__check"
+                  = task.title
+                .task-list__icons
+                  = link_to group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
+                  = link_to edit_group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "edit"
+                  = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
+                    = icon "fas", "trash-alt"
+          - else
+            - if task.category_id == 3
+              %li.task-box__content--list
+                .task-list__title
+                  = task.title
+                .task-list__icons
+                  = link_to group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "file-alt"                                                  #each文でtaskに情報を代入しているため、引数は@taskではなくtaskとなる
+                  = link_to edit_group_task_path(@group, task), class: "list-link" do
+                    = icon "fas", "edit"
+                  = link_to group_task_path(@group, task), method: :delete, data: {confirm: "本当に削除しますか？"}, class: "list-link" do
+                    = icon "fas", "trash-alt"
 
 = render "share/navigation"

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,12 +1,12 @@
 .task-wrap__details
-  .deadline-box
+  %section.deadline-box
     .deadline-box__icon
       = icon "fa", "bell"
       .deadline-box__header
         Deadline
       .deadline-box__time
         = @task.deadline.strftime("%Y/%m/%d %H:%M")
-  .details-box
+  %section.details-box
     .details-box__title
       = @task.title
     .details-box__content
@@ -15,7 +15,7 @@
       - if @task.task_images.present?
         - @task.task_images.each do |task_images|
           = image_tag task_images.image.url, height: "100px", width: "100px", class: "task-image"
-  .details-member
+  %section.details-member
     .details-member__header
       .details-member__header--icon
         = icon "fa", "check-square", class: "check-square"
@@ -30,9 +30,10 @@
               = task.name
         - else
           .details-member__list--image
-            = icon "fas", "user", class: "task-avatar__blank"
+            = icon "fa", "user-circle", class: "task-avatar__blank"
             .details-member__list--name
               = task.name
+  -# created_at &nbsp; #{@task.created_at.strftime("%Y/%m/%d %H:%M")}
 
 = render "share/navigation"
 


### PR DESCRIPTION
#WHAT
変更点
・indexページで投稿されたタスクに、current_userが含まれている場合、識別するためのアイコンを表示するようにした。
・タスク追加アイコンを変更
・formボタンの表示名を変更
・showページのuserアイコンを変更

#WHY
自分が担当するタスクを視覚的に認識し易くすることで、作業効率が良くなることが期待できるため