### PR TITLE
viewの表示を変更

### DIFF
--- a/app/assets/stylesheets/_groups.scss
+++ b/app/assets/stylesheets/_groups.scss
@@ -136,6 +136,13 @@ margin: 3px auto 30px;
 }
 
 
+.user-search-not-remove{
+  display: inline-block;
+  margin-left: 5em;
+  color: #BA002F;
+}
+
+
 .form-field__search{
   margin-bottom: 2em;
 }

--- a/app/assets/stylesheets/_groups.scss
+++ b/app/assets/stylesheets/_groups.scss
@@ -58,6 +58,12 @@ margin: 3px auto 30px;
 }
 
 
+.group-alert{
+  color: red;
+  margin-bottom: 5.5em;
+}
+
+
 
 .select-wrap{
   position: fixed;

--- a/app/views/groups/_errors.html.haml
+++ b/app/views/groups/_errors.html.haml
@@ -1,0 +1,5 @@
+- if @group.errors.any?
+  .group-alert
+    %ul
+      -@group.errors.full_messages.each do |message|
+        %li= message

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,4 +1,4 @@
-= form_with model: group, local: true do |f|
+= form_with model: @group, local: true do |f|
   = render "groups/errors"
   .form-field
     = f.label :name, "Group Name"
@@ -21,7 +21,10 @@
           .group-user.clearfix{ id: "group-user-#{user.id}" }
             = f.hidden_field :id, name: "group[user_ids][]", value: user.id
             %p.group-user__name= user.name
-            - unless user.id == current_user.id
+            - if @group.user_ids.include?(current_user.id) && @group.user_ids.length == 1
+              .user-search-not-remove
+                削除不可
+            - else
               %a.user-search-remove.group-user__btn.group-user__btn--remove{ 'data-user-id': user.id } 削除
     .form-field.clearfix
   .actions

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,8 +1,9 @@
 = form_with model: group, local: true do |f|
+  = render "groups/errors"
   .form-field
     = f.label :name, "Group Name"
     %br/
-    = f.text_field :name, autofocus: true, class: "input-field", placeholder: "例)   1/1   新潟コンサート・朱鷺メッセ公演", required: true
+    = f.text_field :name, autofocus: true, class: "input-field", placeholder: "例)   1/1   新潟コンサート・朱鷺メッセ公演"
   .form-field
     = f.label :notice, "Group Notice"
     %br/
@@ -24,4 +25,4 @@
               %a.user-search-remove.group-user__btn.group-user__btn--remove{ 'data-user-id': user.id } 削除
     .form-field.clearfix
   .actions
-    = f.submit "Create!", class: "form-submit__green"
+    = f.submit "send", class: "form-submit__green"


### PR DESCRIPTION
#WHAT
・エラーメッセージを実装
・ユーザーを削除出来るケースを変更

#WHY
・エラーメッセージを表示することで、どの項目が無効なのかユーザーに知らせることが出来るため
・任意に自分をグループから外せることで、他のユーザーから削除してもらう手間が無くなるため
