### PR TITLE
条件によってユーザー名の表示を変更

### DIFF
--- a/app/assets/stylesheets/_toppages.scss
+++ b/app/assets/stylesheets/_toppages.scss
@@ -123,23 +123,22 @@
     height: 100px;
     &__avatar{
       display: inline-block;
-      margin-right: 1.5em;
-      margin-left: 1.5em;
+      margin-right: 0.4em;
+      margin-left: 0.4em;
+      width: 6.5em;
     }
     &__name{
-      font-size: 1.1em;
-      max-width: 54.5px;
       overflow: hidden;
     }
   }
   .all-avatar{
-    height: 3.5em;
-    width: 3.5em;
+    height: 3.75em;
+    width: 3.75em;
     border-radius: 50%;
   }
   .all-avatar__blank{
-    font-size: 3.5em;
-    padding-bottom: 8px;
+    font-size: 3.75em;
+    padding-bottom: 6px;
   }
 }
 

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -28,12 +28,20 @@
           .users-bar__avatar
             = image_tag users.avatar, class: "all-avatar"
             .users-bar__name
-              = users.name
+              - japanese = /\A[ぁ-んァ-ン一-龥]/
+              - english = /\A[\w\s]+\z/
+              = users.name[0..4] << "..." if users.name.match(japanese) && users.name.length > 5
+              = users.name[0..6] << "..." if users.name.match(english) && users.name.length > 7
+              = users.name unless users.name.match(japanese) && users.name.length > 5 or users.name.match(english) && users.name.length > 7
         - else
           .users-bar__avatar
             = icon "fas", "user-circle", class: "all-avatar__blank"
             .users-bar__name
-              = users.name
+              - japanese = /\A[ぁ-んァ-ン一-龥]/
+              - english = /\A[\w\s]+\z/
+              = users.name[0..4] << "..." if users.name.match(japanese) && users.name.length > 5
+              = users.name[0..6] << "..." if users.name.match(english) && users.name.length > 7
+              = users.name unless users.name.match(japanese) && users.name.length > 5 or users.name.match(english) && users.name.length > 7
 
   .toppage-information
     .information-header

--- a/app/views/toppages/_information.html.haml
+++ b/app/views/toppages/_information.html.haml
@@ -47,7 +47,7 @@
                 = status.created_at.strftime("%Y/%m/%d %H:%M")
               .information-box__result
                 = status.user.name
-                のSTATUSが作成されました
+                のステータスが作成されました
             .information-border
             %br/
 
@@ -59,7 +59,7 @@
                 = chat.created_at.strftime("%Y/%m/%d %H:%M")
               .information-box__result
                 = chat.user.name
-                がCHATを更新しました
+                がチャットを更新しました
             .information-border
             %br/
 


### PR DESCRIPTION
#WHAT
正規表現にマッチ、かつユーザー名の長さによって表示を変更した

#WHY
ユーザー名を最大長の長さに登録したユーザーが表示された時に、隣接するユーザーのビューに影響を与えないため