### PR TITLE
条件によってユーザー名の表示を変更

### DIFF
--- a/app/assets/stylesheets/_groups.scss
+++ b/app/assets/stylesheets/_groups.scss
@@ -126,6 +126,7 @@ margin: 3px auto 30px;
     display: inline-block;
     margin-left: 5em;
     cursor: pointer;
+    white-space: nowrap;
     &--add {
       color: #008BBB;
     }
@@ -140,6 +141,7 @@ margin: 3px auto 30px;
   display: inline-block;
   margin-left: 5em;
   color: #BA002F;
+  white-space: nowrap;
 }
 
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -20,7 +20,12 @@
         - group.users.each do |user|
           .group-user.clearfix{ id: "group-user-#{user.id}" }
             = f.hidden_field :id, name: "group[user_ids][]", value: user.id
-            %p.group-user__name= user.name
+            %p.group-user__name
+              - japanese = /\A[ぁ-んァ-ン一-龥]/
+              - english = /\A[\w\s]+\z/
+              = user.name[0..19] << "..." if user.name.match(japanese) && user.name.length > 20
+              = user.name[0..24] << "..." if user.name.match(english) && user.name.length > 25
+              = user.name unless user.name.match(japanese) && user.name.length > 20 or user.name.match(english) && user.name.length > 24
             - if @group.user_ids.include?(current_user.id) && @group.user_ids.length == 1
               .user-search-not-remove
                 削除不可


### PR DESCRIPTION
#WHAT
正規表現にマッチ、かつユーザー名の長さによって表示を変更

#WHY
ユーザー名を最大長で登録したユーザーが表示された時に、隣接するユーザーのビューに影響を与えないため
