### PR TITLE
ボタンの位置を入れ替え

### DIFF
--- a/app/views/toppages/index.html.haml
+++ b/app/views/toppages/index.html.haml
@@ -13,9 +13,9 @@
 
   %ul.group-bar__blank
     %li.group-bar__blank--button
-      = link_to "Select Group", groups_path, class: "group-bar__list--action"
-    %li.group-bar__blank--button
       = link_to "New Group", new_group_path, class: "group-bar__list--action"
+    %li.group-bar__blank--button
+      = link_to "Select Group", groups_path, class: "group-bar__list--action"
 
   .toppage-information
     .information-header


### PR DESCRIPTION
#WHAT
ボタンの位置を入れ替え

#WHY
informationの説明に対して、ボタンの位置が逆だったため入れ替えた