### PR TITLE
database.ymlを本番環境のmysqlに合わせて設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -52,3 +52,4 @@ production:
   database: EventGeek_production
   username: EventGeek
   password: <%= ENV['EVENTGEEK_DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
#WHAT
database.ymlを本番環境のmysqlに合わせて設定

#WHY
database.ymlを本番環境のmysqlに合わせることで、unicorn_railsのコマンドを使えるようにするため