### PR TITLE
database.ymlを本番環境のmysqlに合わせて設定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,6 +50,6 @@ test:
 production:
   <<: *default
   database: EventGeek_production
-  username: EventGeek
-  password: <%= ENV['EVENTGEEK_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
   socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
#WHAT
database.ymlを本番環境のmysqlに合わせて設定

#WHY
記述が間違っていたため、再度編集した