### PR TITLE
collection_check_boxesの中身を変更

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,6 +7,7 @@ class TasksController < ApplicationController
     @task = Task.all
     @task = Task.new
     5.times{@task.task_images.build}
+    @user = @group.users.all
     @category = Category.all
   end
 
@@ -32,6 +33,7 @@ class TasksController < ApplicationController
 
   def edit
     @task = Task.find(params[:id])
+    @user = @group.users.all
     @category = Category.all
     5.times{@task.task_images.build} if @task.task_images.blank?
     4.times{@task.task_images.build} if @task.task_images.present? && @task.task_images.count == 1

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -24,7 +24,7 @@
         = f.label :user_ids, "Add Member"
         %br/
         .check-box
-          = f.collection_check_boxes  :user_ids, User.all, :id, :name
+          = f.collection_check_boxes  :user_ids, @user, :id, :name
       .form-field
         = f.label :deadline
         %br/

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -28,7 +28,7 @@
         = f.label :user_ids, "Add Member"
         %br/
         .check-box
-          = f.collection_check_boxes  :user_ids, User.all, :id, :name
+          = f.collection_check_boxes  :user_ids, @user, :id, :name
       .form-field__js
         = f.label :deadline
         %br/


### PR DESCRIPTION
#WHAT
collection_check_boxesの中身を変更し
グループに所属しているメンバーだけを取り出すように変更した

#WHY
全てのユーザーが取り出されてしまうと、グループを作成した意味が無くなってしまう、かつ登録者が増えた時に探すのが大変になってしまうため。