### PR TITLE
画像アップロード関連を修正

### DIFF
--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -1,34 +1,5 @@
-// $(document).on('turbolinks:load', function(){
-//   $('#myfile').change(function(e){
-//     //ファイルオブジェクトを取得する
-//     var file = e.target.files[0];
-//     var reader = new FileReader();
-
-//     //画像でない場合は処理終了
-//     if(file.type.indexOf("image") < 0){
-//       alert("画像ファイルを指定してください。");
-//       return false;
-//     }
-
-//     //アップロードした画像を設定する
-//     reader.onload = (function(file){
-//       return function(e){
-//         $("#avatar").attr("src", e.target.result);
-//         $("#avatar").attr("title", file.name);
-//       };
-//     })(file);
-//     reader.readAsDataURL(file);
-
-//   });
-// });
-
-
-
-
-
-
 $(document).on('turbolinks:load', function(){
-  var view_box = $(".icon-select");
+  var view_box = $(".group-icon__select");
 
   $(".input-file").on('change', function(){
     var fileprop = $(this).prop('files')[0],
@@ -45,7 +16,7 @@ $(document).on('turbolinks:load', function(){
       return false;
     }
 
-    var img = '<div class="img_view"><img alt="" class="selected-image"><p><a href="#" class="form_img__delete">削除</a></p></div>';
+    var img = '<div class="img_view"><img alt="" class="group-icon--preview"><p><a href="#" class="form_img__delete">削除</a></p></div>';
 
     view_box.append(img);
 
@@ -71,10 +42,6 @@ $(document).on('turbolinks:load', function(){
     });
     return false;
   }
-
-  $(".form-submit").on('click', function(){
-    $(".input-file").prop("disabled", false);
-  });
 
   $(".form-submit--black").on('click', function(){
     $(".input-file").prop("disabled", false);

--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -21,6 +21,15 @@
               2px -2px 0  #008BBB,
               -2px -2px 0  #008BBB;
 }
+
+
+
+.alert{
+  color: red;
+}
+
+
+
 .form-field{
   margin-bottom: 3.5em;
   font-size: 17px;
@@ -48,6 +57,29 @@
     background: white;
   }
 }
+.input-field::placeholder{
+  padding-top: 1.6%;
+}
+.input-field__text{
+  width: 21.5em;
+  height: 5em;
+  padding: 0.3em;
+  box-sizing: border-box;
+}
+
+
+
+.form-icon__title{
+  font-size: 18px;
+  display: inline;
+  margin-left: 6.3em;
+}
+.form-description{
+  display: inline;
+  font-size: 13px;
+  margin-left: 5px;
+}
+
 
 
 .selected-image{
@@ -60,6 +92,7 @@
   text-decoration: none;
   font-size: 1.15em;
 }
+
 
 
 .form-submit{
@@ -130,37 +163,7 @@
 }
 
 
+
 .copyright{
   font-size: 3px;
-}
-
-
-.form-description{
-  display: inline;
-  font-size: 13px;
-  margin-left: 5px;
-}
-
-.form-icon__title{
-  font-size: 18px;
-  display: inline;
-  margin-left: 6.3em;
-}
-
-
-.input-field::placeholder{
-  padding-top: 1.6%;
-}
-
-
-.input-field__text{
-  width: 21.5em;
-  height: 5em;
-  padding: 0.3em;
-  box-sizing: border-box;
-}
-
-
-.alert{
-  color: red;
 }

--- a/app/assets/stylesheets/_groups.scss
+++ b/app/assets/stylesheets/_groups.scss
@@ -271,6 +271,18 @@ margin: 3px auto 30px;
 
 
 
+.group-icon__select{
+  display: inline-block;
+  font-size: 16px;
+}
+
+
+.group-icon--preview{
+  height: 8.5em;
+  width: 8.5em;
+}
+
+
 .group-user {
   padding: 0 0 5px;
   line-height: 3.5em;
@@ -326,6 +338,7 @@ margin: 3px auto 30px;
   margin: 7em 0 5em;
   text-align: center;
 }
+
 
 .javascript-back{
   text-decoration: none;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -23,7 +23,7 @@ class GroupsController < ApplicationController
     @group = Group.new(group_params)
     @group_category = GroupCategory.all
     if @group.save
-      redirect_to root_path
+      redirect_to group_path(@group)
     else
       render :new
     end
@@ -41,7 +41,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
-      redirect_to root_path
+      redirect_to group_path(@group)
     else
       redirect_to edit_group_path(@group)
     end

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -1,5 +1,5 @@
 class Chat < ApplicationRecord
   belongs_to :user
   belongs_to :group
-  mount_uploader :image, ImageUploader
+  mount_uploader :image, ImageUploader, dependent: :destroy
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,7 +7,7 @@ class Group < ApplicationRecord
 
   belongs_to :group_category
 
-  mount_uploader :image, ImageUploader
+  mount_uploader :image, ImageUploader, dependent: :destroy
 
 
   validates :name, presence: { message: "入力してください" }

--- a/app/models/task_image.rb
+++ b/app/models/task_image.rb
@@ -1,4 +1,4 @@
 class TaskImage < ApplicationRecord
   belongs_to :task
-  mount_uploader :image, ImageUploader
+  mount_uploader :image, ImageUploader, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,8 @@ class User < ApplicationRecord
   has_many :tasks, through: :task_users
   has_many :chats, dependent: :destroy
   has_one  :status, dependent: :destroy
-  has_one_attached :avatar
+
+  mount_uploader :avatar, ImageUploader, dependent: :destroy
 
 
   validates_presence_of :avatar, allow_blank: true   #allow_blank: trueで空の入力（値無し）を許可する

--- a/app/views/chats/_message.html.haml
+++ b/app/views/chats/_message.html.haml
@@ -3,8 +3,8 @@
     .message
       .upper-contents
         .upper-contents__icon
-        - if chat.user.avatar.attached?
-          = image_tag chat.user.avatar, class: "icon"
+        - if chat.user.avatar.present?
+          = image_tag chat.user.avatar.url, class: "icon"
         - else
           = icon "fas", "user-circle",  class: "icon-blank"
         .upper-contents__user-name
@@ -31,8 +31,8 @@
     .message
       .upper-contents
         .upper-contents__icon
-        - if chat.user.avatar.attached?
-          = image_tag chat.user.avatar, class: "icon"
+        - if chat.user.avatar.present?
+          = image_tag chat.user.avatar.url, class: "icon"
         - else
           = icon "fas", "user-circle",  class: "icon-blank"
         .upper-contents__user-name

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -9,7 +9,7 @@
     .form-description
       ※設定は任意です
       .form-field
-        = f.label :image, "ファイルを選択", class: "icon-select" do
+        = f.label :image, "ファイルを選択", class: "group-icon__select" do
           = icon "fa", "image", class: "label__image"
           = f.file_field :image, class: "input-file"
   .form-field

--- a/app/views/groups/show.html.haml
+++ b/app/views/groups/show.html.haml
@@ -5,7 +5,7 @@
       .toppage-header__awesome
         = icon "fa", "bolt", class: "bolt"
       .toppage-header__title
-        #{@group.name}
+        = @group.name
     .slideDown-awesome
       = icon "fa", "align-justify", class: "storage-awesome"
 
@@ -24,9 +24,9 @@
   .toppage-users
     .users-bar
       -@group.users.each do |users|
-        -if users.avatar.attached?
+        -if users.avatar.present?
           .users-bar__avatar
-            = image_tag users.avatar, class: "all-avatar"
+            = image_tag users.avatar.url, class: "all-avatar"
             .users-bar__name
               - japanese = /\A[ぁ-んァ-ン一-龥]/
               - english = /\A[\w\s]+\z/

--- a/app/views/share/_account.html.haml
+++ b/app/views/share/_account.html.haml
@@ -32,9 +32,9 @@
         .account-field__data--headline
           基本情報
         .account-field__data--contents
-          - if current_user.avatar.attached?   #has_one_attachedで画像機能を作成した場合、attached?で画像の有無を確認する。存在すればtrueを返す
+          - if current_user.avatar.present?
             .account-field__icon
-              = image_tag current_user.avatar, class: "pesonal-icon"
+              = image_tag current_user.avatar.url, class: "pesonal-icon"
           - else
             .account-field__icon
               = icon "fas", "user-circle", class: "account-icon"

--- a/app/views/share/_header.html.haml
+++ b/app/views/share/_header.html.haml
@@ -1,6 +1,0 @@
-.header-wrap
-  .header
-    .header__working
-      イベント名
-    .header__member
-      = current_user.name

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -23,9 +23,9 @@
         Person in charge
     .details-member__list
       - @task.users.each do |users|
-        -if users.avatar.attached?
+        -if users.avatar.present?
           .details-member__list--image
-            = image_tag users.avatar, class: "task-avatar"
+            = image_tag users.avatar.url, class: "task-avatar"
             .details-member__list--name
               - japanese = /\A[ぁ-んァ-ン一-龥]/
               - english = /\A[\w\s]+\z/

--- a/app/views/users/confirmation.html.haml
+++ b/app/views/users/confirmation.html.haml
@@ -6,9 +6,9 @@
     .procedure-box__header
       登録内容の確認
     .confirmation-contents
-      - if @user.avatar.attached?   #has_one_attachedで画像機能を作成した場合、attached?で画像の有無を確認する。存在すればtrueを返す
+      - if @user.avatar.present?
         .confirmation-contents__icon
-          = image_tag @user.avatar, class: "procedure-icon"
+          = image_tag @user.avatar.url, class: "procedure-icon"
         %table.confirmation-contents__table
           %thead
             %tr

--- a/db/migrate/20191127080349_devise_create_users.rb
+++ b/db/migrate/20191127080349_devise_create_users.rb
@@ -5,6 +5,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
     create_table :users do |t|
       ## Database authenticatable
       t.string :name,                null: false, unique: true, index: true
+      t.text :avatar
       t.string :email,              null: false, unique: true
       t.string :encrypted_password, null: false, unique: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -167,6 +167,7 @@ ActiveRecord::Schema.define(version: 2020_04_28_162508) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
+    t.text "avatar"
     t.string "email", null: false
     t.string "encrypted_password", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
#WHAT
・グループ作成・編集フォームで、画像のプレビュー機能を実装
・ユーザーのavatarをcarrierwaveでのアップロードに変更

#WHY
選択した画像をプレビュー出来ることで、ユーザーに画像選択の情報を知らせることが出来るから。
active_storageを使用していたが、AWSのS3に保存された時に、保存情報が階層化されなく使い勝手が良くないと判断したので、carrierwaveに変更した。