### PR TITLE
グループ関連の機能を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,5 +1,6 @@
 class ChatsController < ApplicationController
 
+  before_action :authenticate_user!
   before_action :set_group
 
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -40,6 +40,12 @@ class GroupsController < ApplicationController
 
 
   def show
+    # ログインしているユーザーが所属している全グループのカテゴリーが、現在選択中のグループのカテゴリーと等しく
+    # ログインしているユーザーが所属している全グループの内、現在選択中のグループと等しくないグループを取り出す
+    @same_category_groups = current_user.groups.where(group_category_id: "#{@group.group_category_id}").where.not(id: "#{@group.id}")
+
+    # 上記の処理は下記と同等
+    # - if current_user && group.group_category_id == @group.group_category_id && group != @group
   end
 
 

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,5 +1,6 @@
 class MypagesController < ApplicationController
 
+  before_action :authenticate_user!
   before_action :set_group
 
 

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -1,5 +1,6 @@
 class StatusesController < ApplicationController
 
+  before_action :authenticate_user!
   before_action :set_group
   before_action :set_status, only: [:edit, :update]
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
 
+  before_action :authenticate_user!
   before_action :set_group
   before_action :set_task, only: [:show, :edit, :update, :destroy]
   before_action :set_task_images, only: [:edit]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
 
+  before_action :authenticate_user!, only: [:show, :new_icon, :new_email, :new_password, :edit, :update]
   before_action :set_user, only: [:confirmation, :compleate, :show, :new_icon, :new_email, :new_password, :edit, :update, :destroy]
 
 
@@ -53,7 +54,7 @@ class UsersController < ApplicationController
 
 
   def destroy
-    if current_user.destroy
+    if @user.destroy
       redirect_to registration_path
     else
       render :show

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -17,7 +17,7 @@
         %th.form-table__row--header
           = f.label :name, "※Group Name"
         %td.form-table__row--data
-          = f.text_field :name, autofocus: true, class: "input-field", maxlength: "35", placeholder: "例) 1/1  音楽イベント・駅前会場"
+          = f.text_field :name, autofocus: false, class: "input-field", maxlength: "35", placeholder: "例) 1/1  音楽イベント・駅前会場"
 
       // イメージ
       %tr.form-table__row
@@ -43,7 +43,7 @@
         %th.form-table__row--header
           = f.label :notice, "Group Notice"
         %td.form-table__row--data
-          = f.text_area :notice, autofocus: true, class: "text-area", placeholder: "共有事項を入力してください"
+          = f.text_area :notice, autofocus: false, class: "text-area", placeholder: "共有事項を入力してください"
 
       // カテゴリー
       %tr.form-table__row

--- a/app/views/groups/_related.html.haml
+++ b/app/views/groups/_related.html.haml
@@ -1,44 +1,41 @@
 .group-related-wrap
   .header
     同じカテゴリー
+
   // 配列をランダムにして先頭から20件取得する
-  - current_user.groups.shuffle.first(30).each do |group|
-    // ログインしているユーザーが所属している全グループのカテゴリーが、現在選択中のグループのカテゴリーと等しく
-    // ログインしているユーザーが所属している全グループの内、現在選択中のグループと等しくないグループを取り出す
-    - if current_user && group.group_category_id == @group.group_category_id && group != @group
+  - @same_category_groups.shuffle.first(30).each do |group|
+    // 各グループ情報の入れ物
+    = link_to group_path(group.id), class: "group-box" do
+      // サムネイル
+      .group-box__thumbnail
+        - if group.image.present?
+          = image_tag group.image.url, class: "register-image"
+        - else
+          = image_tag "https://truck-kinkisharyo.com/wp/wp-content/uploads/2019/01/noimage.jpg", class: "blank-image"
 
-      // 各グループ情報の入れ物
-      = link_to group_path(group.id), class: "group-box" do
-        // サムネイル
-        .group-box__thumbnail
-          - if group.image.present?
-            = image_tag group.image.url, class: "register-image"
+      // グループ情報
+      .group-box__list
+        .name-section
+          // 文字列の先頭\A ∼ 文字列の末尾\zが、ひらがな・カタカナ・漢字、いずれかの1文字[] を1回以上繰り返す+
+          - japanese = /\A[ぁ-んァ-ン一-龥]+\z/
+
+          // 文字列の先頭\A ∼ 文字列の末尾\zが、単語構成文字\w  [a-zA-Z0-9_]と空白文字\s  [\t\r\n\f]のいずれかの1文字[] を1回以上繰り返す+
+          - english = /\A[\w\s]+\z/
+
+          // 文字列の先頭\A ∼ 文字列の末尾\zが、ひらがな・カタカナ・漢字、単語構成文字\w  [a-zA-Z0-9_]、非単語構成文字\W  [^a-zA-Z0-9_]、空白文字\s  [\t\r\n\f]、非空白文字\S  [^ \t\r\n\f]のいずれかの1文字[] を1回以上繰り返す+
+          - all_characters = /\A[ぁ-んァ-ン一-龥\w\W\s\S]+\z/
+
+          - if group.name.match(japanese) && group.name.length > 13
+            = group.name[0..12] << "..."
+          - elsif group.name.match(english) && group.name.length > 20
+            = group.name[0..19] << "..."
+          - elsif group.name.match(all_characters) && group.name.length > 15
+            = group.name[0..14] << "..."
           - else
-            = image_tag "https://truck-kinkisharyo.com/wp/wp-content/uploads/2019/01/noimage.jpg", class: "blank-image"
+            = group.name
 
-        // グループ情報
-        .group-box__list
-          .name-section
-            // 文字列の先頭\A ∼ 文字列の末尾\zが、ひらがな・カタカナ・漢字、いずれかの1文字[] を1回以上繰り返す+
-            - japanese = /\A[ぁ-んァ-ン一-龥]+\z/
-
-            // 文字列の先頭\A ∼ 文字列の末尾\zが、単語構成文字\w  [a-zA-Z0-9_]と空白文字\s  [\t\r\n\f]のいずれかの1文字[] を1回以上繰り返す+
-            - english = /\A[\w\s]+\z/
-
-            // 文字列の先頭\A ∼ 文字列の末尾\zが、ひらがな・カタカナ・漢字、単語構成文字\w  [a-zA-Z0-9_]、非単語構成文字\W  [^a-zA-Z0-9_]、空白文字\s  [\t\r\n\f]、非空白文字\S  [^ \t\r\n\f]のいずれかの1文字[] を1回以上繰り返す+
-            - all_characters = /\A[ぁ-んァ-ン一-龥\w\W\s\S]+\z/
-
-            - if group.name.match(japanese) && group.name.length > 13
-              = group.name[0..12] << "..."
-            - elsif group.name.match(english) && group.name.length > 20
-              = group.name[0..19] << "..."
-            - elsif group.name.match(all_characters) && group.name.length > 15
-              = group.name[0..14] << "..."
-            - else
-              = group.name
-
-          .content-section
-            作成日 &nbsp;
-            = group.created_at.strftime("%Y/%m/%d")
-            %br/
-            = group.group_category.name
+        .content-section
+          作成日 &nbsp;
+          = group.created_at.strftime("%Y/%m/%d")
+          %br/
+          = group.group_category.name

--- a/app/views/statuses/_form.html.haml
+++ b/app/views/statuses/_form.html.haml
@@ -25,7 +25,7 @@
             Company
           = f.fields_for :company do |company|
             %td.form-table__row--data
-              = company.text_field :name, autofocus: true, autocomplete: true, placeholder: "例) 株式会社イベント", class: "input-field"
+              = company.text_field :name, autofocus: false, autocomplete: true, placeholder: "例) 株式会社イベント", class: "input-field"
 
         // 稼働時間選択
         %tr.form-table__row
@@ -92,7 +92,7 @@
             Set up
           = f.fields_for :position do |position|
             %td.form-table__row--data
-              = position.text_field :set_up, autofocus: true, autocomplete: true, placeholder: "例) 設営", class: "input-field"
+              = position.text_field :set_up, autofocus: false, autocomplete: true, placeholder: "例) 設営", class: "input-field"
 
         // 開場時のポジション入力
         %tr.form-table__row
@@ -100,7 +100,7 @@
             Opening
           = f.fields_for :position do |position|
             %td.form-table__row--data
-              = position.text_field :opening, autofocus: true, autocomplete: true, placeholder: "例) 入場口受付", class: "input-field"
+              = position.text_field :opening, autofocus: false, autocomplete: true, placeholder: "例) 入場口受付", class: "input-field"
 
         // 開演時のポジション入力
         %tr.form-table__row
@@ -108,7 +108,7 @@
             Start
           = f.fields_for :position do |position|
             %td.form-table__row--data
-              = position.text_field :start, autofocus: true, autocomplete: true, placeholder: "例) 客席案内", class: "input-field"
+              = position.text_field :start, autofocus: false, autocomplete: true, placeholder: "例) 客席案内", class: "input-field"
 
         // 休憩時のポジション入力
         %tr.form-table__row
@@ -116,7 +116,7 @@
             Break
           = f.fields_for :position do |position|
             %td.form-table__row--data
-              = position.text_field :break, autofocus: true, autocomplete: true, placeholder: "例) 再入場対応", class: "input-field"
+              = position.text_field :break, autofocus: false, autocomplete: true, placeholder: "例) 再入場対応", class: "input-field"
 
         // 終演時のポジション入力
         %tr.form-table__row
@@ -124,7 +124,7 @@
             End
           = f.fields_for :position do |position|
             %td.form-table__row--data
-              = position.text_field :end, autofocus: true, autocomplete: true, placeholder: "例) 会場内客出し", class: "input-field"
+              = position.text_field :end, autofocus: false, autocomplete: true, placeholder: "例) 会場内客出し", class: "input-field"
 
         // 撤去時のポジション入力
         %tr.form-table__row
@@ -132,7 +132,7 @@
             Clean up
           = f.fields_for :position do |position|
             %td.form-table__row--data
-              = position.text_field :clean_up, autofocus: true, autocomplete: true, placeholder: "例) 撤去", class: "input-field"
+              = position.text_field :clean_up, autofocus: false, autocomplete: true, placeholder: "例) 撤去", class: "input-field"
 
     // 送信ボタン
     %button.submit-button

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -20,14 +20,14 @@
             %th.form-table__row--header
               = f.label :title, "※Task Title"
             %td.form-table__row--data
-              = f.text_field :title, class: "input-field", autofocus: true, placeholder: "例) 会場の設営"
+              = f.text_field :title, class: "input-field", autofocus: false, placeholder: "例) 会場の設営"
 
           // タスクの内容入力
           %tr.form-table__row
             %th.form-table__row--header
               = f.label :content, "※Task Content"
             %td.form-table__row--data
-              = f.text_area :content, class: "text-area", autofocus: true, placeholder: "詳細を入力してください"
+              = f.text_area :content, class: "text-area", autofocus: false, placeholder: "詳細を入力してください"
 
           // イメージ
           %tr.form-table__row

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -13,12 +13,12 @@
       .common-block
         .common-label
           = f.label :title, "※Task Title"
-        = f.text_field :title, class: "input-field", autofocus: true, placeholder: "例) 会場の設営", required: true
+        = f.text_field :title, class: "input-field", autofocus: false, placeholder: "例) 会場の設営", required: true
 
       .common-block
         .common-label
           = f.label :content, "※Task Content"
-        = f.text_area :content, class: "text-area", autofocus: true, required: true, placeholder: "詳細を入力してください"
+        = f.text_area :content, class: "text-area", autofocus: false, required: true, placeholder: "詳細を入力してください"
 
       // イメージ
       .common-block

--- a/app/views/users/new_email.html.haml
+++ b/app/views/users/new_email.html.haml
@@ -6,7 +6,7 @@
       .common-block
         .common-label
           = f.label :email, "New Email"
-        = f.email_field :email, autofocus: true, autocomplete: "email", class: "input-field", placeholder: 'xxx@event.com', required: true
+        = f.email_field :email, autofocus: false, autocomplete: "email", class: "input-field", placeholder: 'xxx@event.com', required: true
 
       .common-block
         = f.submit "send", class: "form-submit", id: "overlay-color"

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -8,7 +8,7 @@
       .common-block
         .common-label
           = f.label :name
-        = f.text_field :name, autofocus: true, maxlength: "20", class: "input-field", placeholder: "Eventer", required: true     #required: trueでtype: inputの空の入力を判別してエラーメッセージを表示してくれる
+        = f.text_field :name, autofocus: false, maxlength: "20", class: "input-field", placeholder: "Eventer", required: true     #required: trueでtype: inputの空の入力を判別してエラーメッセージを表示してくれる
 
       .common-block
         .common-block__heading
@@ -22,7 +22,7 @@
       .common-block
         .common-label
           = f.label :email
-        = f.email_field :email, autofocus: true, autocomplete: "email", class: "input-field", placeholder: 'xxx@event.com', required: true
+        = f.email_field :email, autofocus: false, autocomplete: "email", class: "input-field", placeholder: 'xxx@event.com', required: true
 
       .common-block
         .common-label

--- a/app/views/users/sessions/new.html.haml
+++ b/app/views/users/sessions/new.html.haml
@@ -8,7 +8,7 @@
       .common-block
         .common-label
           = f.label :email
-        = f.email_field :email, autofocus: true, autocomplete: "email", class: "input-field", placeholder: 'xxx@event.com', required: true
+        = f.email_field :email, autofocus: false, autocomplete: "email", class: "input-field", placeholder: 'xxx@event.com', required: true
 
       .common-block
         .common-label


### PR DESCRIPTION
#WHAT
・グループ詳細ページでの関連グループの選定方法を変更
・フォームのオートフォーカスを廃止
・authenticate_user!メソッドの実行タイミングを変更

#WHY
アプリケーション本来の機能を取り戻し、ユーザービリティーの向上を図るために修正を加えた。
