### PR TITLE
グループフォームのインクリメンタルサーチを修正

### DIFF
--- a/app/assets/stylesheets/_top-page.scss
+++ b/app/assets/stylesheets/_top-page.scss
@@ -434,7 +434,6 @@
               display: inline-block;
               padding: 0.8rem 1rem;
               text-align: center;
-              font-weight: 100;
               background: steelblue;
               color: #f0f0f0;
               text-shadow: 1px 1px 0 black;
@@ -447,7 +446,6 @@
               display: inline-block;
               padding: 0.8rem 1rem;
               text-align: center;
-              font-weight: 100;
               background: steelblue;
               color: #f0f0f0;
               text-shadow: 1px 1px 0 black;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,6 +5,7 @@ class GroupsController < ApplicationController
   before_action :set_all_groups, only: [:incremental_search, :category_search, :advanced_search]
   before_action :set_category, only: [:index, :incremental_search, :category_search, :advanced_search]
   before_action :set_ransack, only: [:index, :incremental_search, :category_search, :advanced_search]
+  before_action :set_reference_url, only: [:new, :edit]
 
 
 
@@ -51,6 +52,7 @@ class GroupsController < ApplicationController
 
 
   def edit
+    $reference_group = Group.find(params[:id])
   end
 
 
@@ -123,6 +125,12 @@ class GroupsController < ApplicationController
 
   def set_ransack
     @advanced_search = current_user.groups.ransack(params[:q])
+  end
+
+
+
+  def set_reference_url
+    $reference_url = request.fullpath
   end
 
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,11 +6,19 @@ class UsersController < ApplicationController
 
   def index
     return nil if params[:keyword] == ""   #キーワードに一致しなければnilを返す
-    @users = User.where('name LIKE(?)',"%#{params[:keyword]}%").where.not(id: current_user.id)   #キーワードを含むユーザーを検索して@usersに代入。ただしログインしている自分は除く
+
+    if $reference_group.present? && $reference_url == edit_group_path($reference_group)
+      @excluded_users = User.joins(:groups).where(groups: {id: $reference_group})
+      @user = User.where('name LIKE(?)',"%#{params[:keyword]}%").where.not(id: current_user.id)
+      @users = @user - @excluded_users
+    else
+      @users = User.where('name LIKE(?)',"%#{params[:keyword]}%").where.not(id: current_user.id)   #キーワードを含むユーザーを検索して@usersに代入。ただしログインしている自分は除く
+    end
     respond_to do |format|
       format.html
       format.json
     end
+
   end
 
 

--- a/app/views/groups/_related.html.haml
+++ b/app/views/groups/_related.html.haml
@@ -38,4 +38,5 @@
           作成日 &nbsp;
           = group.created_at.strftime("%Y/%m/%d")
           %br/
-          = group.group_category.name
+          所属人数 &nbsp;
+          #{group.users.length}  人


### PR DESCRIPTION
#WHAT
既にグループに追加済みのユーザーは検索結果に表示しないように機能を修正。

#WHY
重複するユーザーを取り除くことで、どのユーザーを追加していないか把握しやすくなり、検索性の向上が期待出来るため。