### PR TITLE
[update] ステータスフォームのユーザー選択ボックスを修正

### DIFF
--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -3,6 +3,8 @@ class StatusesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_group
   before_action :set_status, only: [:edit, :update]
+  before_action :selected_users, only: [:new, :edit]
+  before_action :new_user_array, only: [:edit]
 
 
 
@@ -18,6 +20,8 @@ class StatusesController < ApplicationController
     @status.build_company
     @status.build_working_hour
     @status.build_position
+
+    @url = request.fullpath
   end
 
 
@@ -29,6 +33,7 @@ class StatusesController < ApplicationController
     if @status.save
       redirect_to group_statuses_path(@group)
     else
+      selected_users
       render :new
     end
   end
@@ -44,6 +49,8 @@ class StatusesController < ApplicationController
     if @status.update(status_params)
       redirect_to group_statuses_path(@group)
     else
+      selected_users
+      new_user_array
       render :edit
     end
   end
@@ -58,6 +65,20 @@ class StatusesController < ApplicationController
 
   def set_status
     @status = Status.find(params[:id])
+  end
+
+
+
+  def selected_users
+    @excluded_users = User.joins(:groups, :statuses).where(groups: {id: "#{@group.id}"}, statuses: {group_id: "#{@group.id}"})
+    @select_users = @group.users - @excluded_users
+  end
+
+
+
+  def new_user_array
+    @edit_user = User.where(id: "#{@status.user_id}")
+    @select_users = @edit_user + @select_users
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   has_many :task_users, dependent: :destroy
   has_many :tasks, through: :task_users
   has_many :chats, dependent: :destroy
-  has_one  :status, dependent: :destroy
+  has_many  :statuses, dependent: :destroy
 
   mount_uploader :avatar, ImageUploader, dependent: :destroy
 

--- a/app/views/statuses/_form.html.haml
+++ b/app/views/statuses/_form.html.haml
@@ -17,7 +17,7 @@
           %th.form-table__row--header
             ※User
           %td.form-table__row--data
-            = f.collection_select(:user_id, @group.users, :id, :name, {prompt: "----"}, class: "select-field")
+            = f.collection_select(:user_id, @select_users, :id, :name, {prompt: "----"}, class: "select-field")
 
         // 会社名入力
         %tr.form-table__row


### PR DESCRIPTION
#WHAT
・新規作成時は、グループ内でステータスが存在しないユーザーのみ、DBから呼び出すように修正。
・編集時は上記の仕様に加え、編集対象のユーザーもDBから呼び出すように修正。

#WHY
グループ内に同じユーザーのステータスが重複して作成されてしまうことを防ぐため。